### PR TITLE
remove dependency on cmp_nvim_lsp, allow custom LSP capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Lazy:
     stream_suggestion = false,
     python_command = "python3",
     filetypes = {'python', 'lua','vim', "markdown"},
+    capabilities = nil, -- LSP capabilities, auto-detected if not provided
     ollama_model_opts = {
         num_predict = 40,
         temperature = 0.1,
@@ -64,6 +65,28 @@ Lazy:
 },
 ```
 For more Ollama customization, see [github.com/ollama/ollama/blob/main/docs/modelfile.md](https://github.com/ollama/ollama/blob/main/docs/modelfile.md)
+
+### LSP Capabilities Configuration
+
+The plugin automatically detects and configures LSP capabilities for optimal completion support:
+
+1. **Auto-detection (default)**: If `capabilities` is not specified, the plugin will:
+   - Try to use `cmp_nvim_lsp.default_capabilities()` if nvim-cmp is installed
+   - Fall back to `vim.lsp.protocol.make_client_capabilities()` if nvim-cmp is not available
+
+2. **Custom capabilities**: You can override the auto-detection by providing your own capabilities:
+   ```lua
+   opts = {
+     capabilities = require('cmp_nvim_lsp').default_capabilities(),
+     -- or use custom capabilities
+     capabilities = vim.tbl_deep_extend('force',
+       vim.lsp.protocol.make_client_capabilities(),
+       { your_custom_capability = true }
+     )
+   }
+   ```
+
+This ensures backward compatibility while allowing the plugin to work without requiring nvim-cmp as a dependency.
 
 ## Usage
 Ollama copilot language server will attach when you enter a buffer and can be viewed using:

--- a/lua/OllamaCopilot/start_up.lua
+++ b/lua/OllamaCopilot/start_up.lua
@@ -1,6 +1,5 @@
 
 local lspconfig = require 'lspconfig'
-local capabilities = require('cmp_nvim_lsp').default_capabilities()
 local ghost_text = require 'OllamaCopilot.ghost_text'
 local ollama_client = require 'OllamaCopilot.lsp_client'
 local configs = require 'lspconfig.configs'
@@ -29,6 +28,7 @@ local default_config = {
     stream_suggestion = false,
     python_command = "python3",
     filetypes = {'python', 'lua','vim', "markdown"},
+    capabilities = nil, -- Will be set automatically or can be overridden by user
     ollama_model_opts = {
         num_predict = 40,
         temperature = 0.1,
@@ -91,6 +91,20 @@ function M.setup(user_config)
     cur_file = cur_file:sub(2, -1):sub(1, -31)
 
     local config = merge_config(user_config)
+
+    -- Handle capabilities: use user-provided capabilities if available,
+    -- otherwise try to use cmp_nvim_lsp if installed, fallback to default
+    local capabilities
+    if config.capabilities then
+        capabilities = config.capabilities
+    else
+        local ok, cmp_nvim_lsp = pcall(require, 'cmp_nvim_lsp')
+        if ok then
+            capabilities = cmp_nvim_lsp.default_capabilities()
+        else
+            capabilities = vim.lsp.protocol.make_client_capabilities()
+        end
+    end
 
     if not configs.ollama_lsp then
         configs.ollama_lsp = {


### PR DESCRIPTION
A little tweak to remove an unused dependency.