### PR TITLE
Update import and notification methods in ollama_lsp

### DIFF
--- a/python/ollama_lsp.py
+++ b/python/ollama_lsp.py
@@ -1,4 +1,4 @@
-from pygls.server import LanguageServer
+from pygls.lsp.server import LanguageServer
 from lsprotocol import types
 #import requests
 from completion_engine import CompletionEngine
@@ -158,10 +158,10 @@ class OllamaServer:
         return
             
     def clear_suggestion(self):
-        self.server.send_notification('$/clearSuggestion',{'message' : "clear current"})
+        self.server.protocol.notify('$/clearSuggestion',{'message' : "clear current"})
 
     def send_suggestion(self, suggestion, line, col, suggestion_type='miscellaneous'):
-        self.server.send_notification('$/tokenStream', {
+        self.server.protocol.notify('$/tokenStream', {
             'line' : line,
             'character' : col,
             'completion': {


### PR DESCRIPTION
Using this plugin with pygls v2 was throwing the following errors:

`from pygls.server import LanguageServer
ImportError: cannot import name 'LanguageServer' from 'pygls.server' `
and "send_notification" method not found.

This method was removed in the newest version without deprecation warning.

Since there is no fixed requirement of pygls version I updated the import and method according to the [documentation](https://pygls.readthedocs.io/en/latest/pygls/howto/migrate-to-v2.html).