### PR TITLE
Fix didChange out-of-range crash in ollama_lsp

### DIFF
--- a/python/ollama_lsp.py
+++ b/python/ollama_lsp.py
@@ -126,7 +126,17 @@ class OllamaServer:
         #send_log(f"Change: {change.text}", change.range.start.line, change.range.start.character, params.text_document.uri)
 
         lines = self.server.workspace.get_text_document(params.text_document.uri).lines
-        line = lines[change.range.start.line][change.range.start.character + 1:]
+        if not hasattr(change, "range") or change.range is None:
+            return
+
+        if change.range.start.line >= len(lines):
+            return
+
+        current_line = lines[change.range.start.line]
+        if change.range.start.character >= len(current_line):
+            line = ""
+        else:
+            line = current_line[change.range.start.character + 1:]
         contains_non_whitespace = bool(re.search(r'[^\s]', line))
 
         if contains_non_whitespace:
@@ -182,5 +192,4 @@ class OllamaServer:
 if __name__ == "__main__":
     server = OllamaServer()
     server.start()
-
 


### PR DESCRIPTION
## Summary
Fixes a crash in `python/ollama_lsp.py` when handling `textDocument/didChange` events with ranges that are missing or out of bounds.

## Problem
`on_change` assumed:
- `change.range` is always present
- `change.range.start.line` is always within `document.lines`
- `change.range.start.character` is always within the current line

In real edit/delete flows, those assumptions can be violated, causing exceptions and the Neovim client to exit with code 1.

## Changes
In `python/ollama_lsp.py` (`on_change`):
- return early if `change.range` is missing/`None`
- return early if `start.line >= len(lines)`
- guard `start.character` before slicing the current line (use empty suffix if out of range)

This keeps behavior unchanged for valid edits while avoiding crashes on edge-case range payloads.

## Validation
- `python3 -m py_compile python/ollama_lsp.py`
- validated in Neovim using local plugin dir
- confirmed `ollama_lsp` stays attached after edit operations that previously caused exits
